### PR TITLE
add sbref to known datatype labels

### DIFF
--- a/converters/heudiconv/hirni_heuristic.py
+++ b/converters/heudiconv/hirni_heuristic.py
@@ -28,6 +28,7 @@ modality_label_map = {
 # map the cannonical modality labels to data_type labels
 datatype_labels_map = {
     'bold': 'func',
+    'sbref': 'func',
 
     'T1w': 'anat',
     'T2w': 'anat',
@@ -319,7 +320,7 @@ def infotodict(seqinfo):  # pragma: no cover
                             get_specval(series_spec, spec_key))
 
             filename += "_GRE"
-            
+
         if data_type == 'fmap':
             # Case 1: Phase difference image and at least one magnitude image
             # sub-<participant_label>/[ses-<session_label>/]


### PR DESCRIPTION
sbref stands for single-band-reference images which can be acquired with multi-band sequences. They are functional images.

For more info: see BIDS (v[ 1.1.1](https://bids.neuroimaging.io/bids_spec.pdf)) specs pdf page 22.