### PR TITLE
add 'magnitude' datatype label

### DIFF
--- a/converters/heudiconv/hirni_heuristic.py
+++ b/converters/heudiconv/hirni_heuristic.py
@@ -53,6 +53,7 @@ datatype_labels_map = {
     'phase2': 'fmap',
     'magnitude1': 'fmap',
     'magnitude2': 'fmap',
+    'magnitude': 'fmap',
     'fieldmap': 'fmap',
 
     'epi': 'fmap',  # TODO?


### PR DESCRIPTION
Some sequences (e.g. Siemens Prisma's) create a single dicom series containing both magnitude images. dcm2niix will correctly infer the integers (1 or 2) from the echo times, but the datatype without the integer is needed for the conversion via the heuristics.