### PR TITLE
NF: add 'phase' datatype label

### DIFF
--- a/converters/heudiconv/hirni_heuristic.py
+++ b/converters/heudiconv/hirni_heuristic.py
@@ -49,6 +49,7 @@ datatype_labels_map = {
     'dwi': 'dwi',
 
     'phasediff': 'fmap',
+    'phase': 'fmap',
     'phase1': 'fmap',
     'phase2': 'fmap',
     'magnitude1': 'fmap',


### PR DESCRIPTION
Similar to #11, I have a single dicom series that contains two phase images.

As @pvavra stated:
> dcm2niix will correctly infer the integers (1 or 2) from the echo times, but the datatype without the integer is needed for the conversion via the heuristics.